### PR TITLE
Allow for escaping null TeX values

### DIFF
--- a/src/Twig.php
+++ b/src/Twig.php
@@ -267,8 +267,18 @@ class Twig extends AbstractExtension
         return $assetPath;
     }
 
-    public function escapeTex(Environment $env, string $string = '', string $charset = 'utf-8'): string
+    /**
+     * Escape a TeX string.
+     *
+     * @param Environment $env The Twig environment. Not used.
+     * @param string|null $string The string to escape.
+     * @param string $charset The charset of the string. Not used.
+     */
+    public function escapeTex(Environment $env, ?string $string = '', string $charset = 'utf-8'): string
     {
+        if ($string === null) {
+            return '';
+        }
         $pat = [
             '/\\\(\s)/',
             '/\\\(\S)/',
@@ -307,6 +317,9 @@ class Twig extends AbstractExtension
      */
     public function escapeCsv(Environment $env, ?string $string = '', string $charset = 'utf-8'): string
     {
+        if ($string === null) {
+            return '';
+        }
         $out = str_replace('"', '""', $string);
         if (strpos($out, '"') !== false || strpos($out, ',') !== false) {
             $out = '"' . $out . '"';

--- a/tests/TwigTest.php
+++ b/tests/TwigTest.php
@@ -17,9 +17,9 @@ class TwigTest extends TestCase
     /**
      * @covers \App\Twig::escapeCsv()
      * @covers \App\Twig::escapeTex()
-     * @dataProvider provideEscapeCsv
+     * @dataProvider provideEscape()
      */
-    public function testEscape(string $strategy, string $in, string $out): void
+    public function testEscape(string $strategy, ?string $in, string $out): void
     {
         $site = new Site(__DIR__ . '/test_site');
         $twig = new Twig($site, new Page($site, '/simple'));
@@ -31,13 +31,15 @@ class TwigTest extends TestCase
     /**
      * @return string[][]
      */
-    public function provideEscapeCsv(): array
+    public function provideEscape(): array
     {
         return [
             'csv' => [ 'csv', 'foo', 'foo' ],
             'csv quotes' => [ 'csv', 'the "foo" thing', '"the ""foo"" thing"' ],
             'csv commas' => [ 'csv', 'foo, bar', '"foo, bar"' ],
             'tex special chars' => [ 'tex', 'A$B"', 'A\textdollar B"' ],
+            'tex allow null' => [ 'tex', null, '' ],
+            'csv allow null' => [ 'csv', null, '' ],
         ];
     }
 


### PR DESCRIPTION
It was already okay for CSV, but this adds a test for that as well
as for TeX.

Bug: #35