### PR TITLE
Add get_xml() Twig function

### DIFF
--- a/example/templates/recent.html.twig
+++ b/example/templates/recent.html.twig
@@ -12,7 +12,7 @@
 
     <p>Another JSON example: {{get_json('https://api.wikitree.com/api.php?action=getProfile&key=Hall-22337').0.profile.LongName}}</p>
 
-    <p>An XML example: {{ dump(get_xml('https://archive.org/download/raobrules1960/raobrules1960_files.xml').xpath('file[source="original"]')) }}</p>
+    <p>An XML example: {{ get_xml('https://archive.org/download/raobrules1960/raobrules1960_files.xml').file.1._attributes.name }}</p>
 
     <ol>
     {% for p in database.query('SELECT * FROM pages WHERE date IS NOT NULL ORDER BY date DESC LIMIT 10') %}

--- a/example/templates/recent.html.twig
+++ b/example/templates/recent.html.twig
@@ -12,6 +12,8 @@
 
     <p>Another JSON example: {{get_json('https://api.wikitree.com/api.php?action=getProfile&key=Hall-22337').0.profile.LongName}}</p>
 
+    <p>An XML example: {{ dump(get_xml('https://archive.org/download/raobrules1960/raobrules1960_files.xml').xpath('file[source="original"]')) }}</p>
+
     <ol>
     {% for p in database.query('SELECT * FROM pages WHERE date IS NOT NULL ORDER BY date DESC LIMIT 10') %}
         <li>

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -30,7 +30,6 @@ use Samwilson\PhpFlickr\PhotosApi;
 use Samwilson\PhpFlickr\PhpFlickr;
 use SimplePie\Item;
 use SimplePie\SimplePie;
-use SimpleXMLElement;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Filesystem\Filesystem;
@@ -374,10 +373,15 @@ final class Twig extends AbstractExtension
         return $this->getJsonOrXml('json', $url);
     }
 
-    public function functionGetXml(?string $url): ?SimpleXMLElement
+    /**
+     * @return mixed[]
+     */
+    public function functionGetXml(?string $url): array
     {
-        $xml = $this->getJsonOrXml('xml', $url);
-        return new SimpleXMLElement($xml);
+        if (!$url) {
+            return [];
+        }
+        return Util::xmlToArray($this->getJsonOrXml('xml', $url));
     }
 
     /**

--- a/src/Twig.php
+++ b/src/Twig.php
@@ -30,6 +30,7 @@ use Samwilson\PhpFlickr\PhotosApi;
 use Samwilson\PhpFlickr\PhpFlickr;
 use SimplePie\Item;
 use SimplePie\SimplePie;
+use SimpleXMLElement;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Psr16Cache;
 use Symfony\Component\Filesystem\Filesystem;
@@ -55,6 +56,7 @@ final class Twig extends AbstractExtension
         'wikidata' => [],
         'flickr' => [],
         'json' => [],
+        'xml' => [],
     ];
 
     public function __construct(Database $db, Site $site, Page $page)
@@ -90,6 +92,7 @@ final class Twig extends AbstractExtension
             new TwigFunction('json_decode', 'json_decode'),
             new TwigFunction('get_json', [$this, 'functionGetJson']),
             new TwigFunction('get_feeds', [$this, 'functionGetFeeds']),
+            new TwigFunction('get_xml', [$this, 'functionGetXml']),
             new TwigFunction('tex_url', [$this, 'functionTexUrl']),
             new TwigFunction('wikidata', [$this, 'functionWikidata']),
             new TwigFunction('commons', [$this, 'functionCommons']),
@@ -366,27 +369,15 @@ final class Twig extends AbstractExtension
         return $response['extract_html'];
     }
 
-    public function functionGetJson(string $url): mixed
+    public function functionGetJson(?string $url): mixed
     {
-        $cacheKey = md5($url);
-        if (isset(self::$data['json'][$cacheKey])) {
-            return self::$data['json'][$cacheKey];
-        }
-        $cache = $this->getCachePool('json_' . parse_url($url, PHP_URL_HOST));
-        $cacheItem = $cache->getItem($cacheKey);
-        if ($cacheItem->isHit()) {
-            return $cacheItem->get();
-        }
-        CommandBase::writeln("Get JSON: $url");
-        $json = (new Client())->get($url)->getBody()->getContents();
-        $response = json_decode($json, true);
-        if (!$response) {
-            throw new Exception("Unable to get JSON from URL: $url");
-        }
-        self::$data['json'][$cacheKey] = $response;
-        $cacheItem->set(self::$data['json'][$cacheKey]);
-        $cache->save($cacheItem);
-        return self::$data['json'][$cacheKey];
+        return $this->getJsonOrXml('json', $url);
+    }
+
+    public function functionGetXml(?string $url): ?SimpleXMLElement
+    {
+        $xml = $this->getJsonOrXml('xml', $url);
+        return new SimpleXMLElement($xml);
     }
 
     /**
@@ -520,5 +511,38 @@ final class Twig extends AbstractExtension
     private function getCachePool(string $subdir): CacheItemPoolInterface
     {
         return new FilesystemAdapter($subdir, 0, $this->site->getDir() . '/cache/');
+    }
+
+    private function getJsonOrXml(string $format, ?string $url): mixed
+    {
+        if ($url === null) {
+            return null;
+        }
+        $cacheKey = md5($url);
+        if (isset(self::$data[$format][$cacheKey])) {
+            return self::$data[$format][$cacheKey];
+        }
+        $cache = $this->getCachePool($format . '_' . parse_url($url, PHP_URL_HOST));
+        $cacheItem = $cache->getItem($cacheKey);
+        if ($cacheItem->isHit()) {
+            return $cacheItem->get();
+        }
+        CommandBase::writeln("Get $format data: $url");
+        $json = (new Client())->get($url)->getBody()->getContents();
+        $response = false;
+        if ($format === 'xml') {
+            $client = new Client();
+            $response = $client->request('GET', $url);
+            $response = $response->getBody()->getContents();
+        } elseif ($format === 'json') {
+            $response = json_decode($json, true);
+        }
+        if (!$response) {
+            throw new Exception("Unable to get $format from URL: $url");
+        }
+        self::$data[$format][$cacheKey] = $response;
+        $cacheItem->set(self::$data[$format][$cacheKey]);
+        $cache->save($cacheItem);
+        return self::$data[$format][$cacheKey];
     }
 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -7,6 +7,7 @@ namespace App;
 use FilesystemIterator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use SimpleXMLElement;
 
 final class Util
 {
@@ -39,5 +40,19 @@ final class Util
                 unlink($file->getPathname());
             }
         }
+    }
+
+    /**
+     * Convert XML into an array structure suitable for use in Twig.
+     *
+     * @param string $xml The XML input.
+     * @return mixed[]
+     */
+    public static function xmlToArray(string $xml): array
+    {
+        $json = json_encode((array) new SimpleXMLElement($xml));
+        // Change the '@attributes' key to have an underscore, for easier use in Twig.
+        $newJson = preg_replace('/"@attributes":/', '"_attributes":', $json);
+        return json_decode($newJson, true);
     }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -47,8 +47,10 @@ final class UtilTest extends TestCase
     /**
      * @covers \App\Util::xmlToArray()
      * @dataProvider provideXmlToArray
+     *
+     * @param mixed[] $array
      */
-    public function testXmlToArray(string $xml, mixed $array): void
+    public function testXmlToArray(string $xml, array $array): void
     {
         $this->assertSame($array, Util::xmlToArray($xml));
     }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -43,4 +43,33 @@ final class UtilTest extends TestCase
         // Clean up.
         Util::rmdir($testDir);
     }
+
+    /**
+     * @covers \App\Util::xmlToArray()
+     * @dataProvider provideXmlToArray
+     */
+    public function testXmlToArray(string $xml, mixed $array): void
+    {
+        $this->assertSame($array, Util::xmlToArray($xml));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function provideXmlToArray(): array
+    {
+        return [
+            [
+                '<foo><p></p></foo>',
+                ['p' => []],
+            ],
+            [
+                '<root><p class="blah"><span>Lorem</span></p></root>',
+                ['p' => [
+                    '_attributes' => ['class' => 'blah'],
+                    'span' => 'Lorem',
+                ]],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Add a new `get_xml()` Twig function that returns a SimpleXMLElement object, so that e.g. `.xpath()` can be used.

Closes #103.